### PR TITLE
Fix: Push then push-pop sequence bug

### DIFF
--- a/lib/Dynamic/circular_buffer.c
+++ b/lib/Dynamic/circular_buffer.c
@@ -76,9 +76,10 @@ bool circular_buffer_push(circularBuffer_t *const circularBuffer, const void *da
 {
     if (circular_buffer_full(circularBuffer))
         return false;
-    
-    (void) memcpy((void *)&circularBuffer->data[circularBuffer->tail + 1], data, circularBuffer->itemSize);
-    circularBuffer->tail += circularBuffer->itemSize;
+
+    int index = (circularBuffer->tail + 1) % (circularBuffer->capacity * circularBuffer->itemSize);
+    (void)memcpy((void *)&circularBuffer->data[index], data, circularBuffer->itemSize);
+    circularBuffer->tail = (circularBuffer->tail + circularBuffer->itemSize) % (circularBuffer->capacity * circularBuffer->itemSize);
  
     return true;
 }
@@ -88,10 +89,11 @@ bool circular_buffer_pop(circularBuffer_t *const circularBuffer, void *data)
 {
     if (circular_buffer_empty(circularBuffer))
         return false;
-  
-    (void) memcpy(data, (void *)&circularBuffer->data[circularBuffer->head + 1], circularBuffer->itemSize);
+
+    int index = (circularBuffer->head + 1) % (circularBuffer->capacity * circularBuffer->itemSize);
+    (void)memcpy(data, (void *)&circularBuffer->data[index], circularBuffer->itemSize);
     circularBuffer->data[circularBuffer->head] = 0;
-    circularBuffer->head += circularBuffer->itemSize;
+    circularBuffer->head = (circularBuffer->head + circularBuffer->itemSize) % (circularBuffer->capacity * circularBuffer->itemSize);
 
     if (circular_buffer_empty(circularBuffer)){
         circularBuffer->head = 0;

--- a/lib/Dynamic/circular_buffer.c
+++ b/lib/Dynamic/circular_buffer.c
@@ -127,7 +127,7 @@ int circular_buffer_free_space(const circularBuffer_t *const circularBuffer)
     int freeSpace = 0;
 
     if (circularBuffer->head > circularBuffer->tail)
-        freeSpace = circularBuffer->capacity - ((circularBuffer->head - circularBuffer->tail) / circularBuffer->itemSize);
+        freeSpace = ((circularBuffer->head - circularBuffer->tail) / circularBuffer->itemSize) - 1;
     else 
         freeSpace = circularBuffer->capacity - ((circularBuffer->tail - circularBuffer->head) / circularBuffer->itemSize);
     

--- a/lib/Static/circular_buffer.c
+++ b/lib/Static/circular_buffer.c
@@ -93,8 +93,9 @@ bool circular_buffer_push(circularBuffer_t *const circularBuffer, const void *da
     if (circular_buffer_full(circularBuffer))
         return false;
     
-    (void) memcpy((void *)&circularBuffer->data[circularBuffer->tail + 1], data, circularBuffer->itemSize);
-    circularBuffer->tail += circularBuffer->itemSize;
+    int index = (circularBuffer->tail + 1) % (circularBuffer->capacity * circularBuffer->itemSize);
+    (void) memcpy((void *)&circularBuffer->data[index], data, circularBuffer->itemSize);
+    circularBuffer->tail = (circularBuffer->tail + circularBuffer->itemSize) % (circularBuffer->capacity * circularBuffer->itemSize);
  
     return true;
 }
@@ -105,9 +106,10 @@ bool circular_buffer_pop(circularBuffer_t *const circularBuffer, void *data)
     if (circular_buffer_empty(circularBuffer))
         return false;
     
-    (void) memcpy(data, (void *)&circularBuffer->data[circularBuffer->head + 1], circularBuffer->itemSize);
+    int index = (circularBuffer->head + 1) % (circularBuffer->capacity * circularBuffer->itemSize);
+    (void) memcpy(data, (void *)&circularBuffer->data[index], circularBuffer->itemSize);
     circularBuffer->data[circularBuffer->head] = 0;
-    circularBuffer->head += circularBuffer->itemSize;
+    circularBuffer->head = (circularBuffer->head + circularBuffer->itemSize) % (circularBuffer->capacity * circularBuffer->itemSize);
 
     if (circular_buffer_empty(circularBuffer)){
         circularBuffer->head = 0;

--- a/lib/Static/circular_buffer.c
+++ b/lib/Static/circular_buffer.c
@@ -143,7 +143,7 @@ int circular_buffer_free_space(const circularBuffer_t *const circularBuffer)
     int freeSpace = 0;
 
     if (circularBuffer->head > circularBuffer->tail)
-        freeSpace = circularBuffer->capacity - ((circularBuffer->head - circularBuffer->tail) / circularBuffer->itemSize) - 1;
+        freeSpace = ((circularBuffer->head - circularBuffer->tail) / circularBuffer->itemSize) - 1;
     else 
         freeSpace = circularBuffer->capacity - ((circularBuffer->tail - circularBuffer->head) / circularBuffer->itemSize) - 1;
     


### PR DESCRIPTION
The current library has a bug that causes the header and tail indicators to overreach into the next buffer. This happens when a nonempty buffer repeatedly receives a sequence of push-pop operations. Each push operation increases the tail and each pop operation increases the head, both without limit.

Here is an exact code to reproduce the problem (assuming a buffer capacity of 4 bytes):

```
// Assume buffer size is 4 bytes

circularBuffer_t* b = circular_buffer_init(sizeof(uint8_t));
uint8_t dataIn = 0xAA;
uint8_t dataOut = 0;

circular_buffer_push(b, &dataIn);

circular_buffer_push(b, &dataIn);
circular_buffer_pop(b, &dataOut);

circular_buffer_push(b, &dataIn);
circular_buffer_pop(b, &dataOut);

circular_buffer_push(b, &dataIn);
circular_buffer_pop(b, &dataOut);

circular_buffer_push(b, &dataIn);
circular_buffer_pop(b, &dataOut);

circular_buffer_push(b, &dataIn);
circular_buffer_pop(b, &dataOut);

```
After the above operations (or any number of more push-pop pair of operations), a debugger can be used to inspect that the tail and head indicators have surpassed the maximum index (in this case 3 since the size is 4) of the `data` array in the circular buffer structure.